### PR TITLE
Combobox Height Calc. Fix for items > 5 & Sidebar items dynamic visibility 

### DIFF
--- a/Controls/Inputs/ComboBox.qml
+++ b/Controls/Inputs/ComboBox.qml
@@ -19,6 +19,7 @@ T.ComboBox {
 	property string placeholderText: qsTr("Placeholder")
 	property color placeholderTextColor: UI.Theme.text.primary
 	property alias color: _textField.color
+	readonly property real delegateHeight: UI.Size.pixel46
 
 	implicitHeight: 48 * UI.Size.scale
 	implicitWidth: (UI.Size.format == UI.Size.Format.Extended ? 319 : 200) * UI.Size.scale
@@ -64,7 +65,7 @@ T.ComboBox {
 
 		rootItem: root
 		ignoreDisabledColoring: root.enabled
-		showPlaceholder: !root.focus && root.text === "" && !root.down && placeholderText !== ""
+		showPlaceholder: !root.focus && root.currentText === "" && !root.down && root.placeholderText !== ""
 		leftIcon: _leftIcon
 		iconContainer: _mainContainer
 	}
@@ -87,7 +88,7 @@ T.ComboBox {
 
 		selectedTextColor: acceptableInput ? root.accent.contrastText : UI.Theme.error.contrastText
 		selectionColor: acceptableInput ? root.accent.main : UI.Theme.error.main
-		placeholderTextColor: UI.Theme.text.primary
+		placeholderTextColor: UI.Theme.text.primary.toString() 
 
 		topPadding: root.type === Inputs.TextField.Type.Standard || root.type === Inputs.TextField.Type.Filled ? root.height * 0.3 : 0
 	}
@@ -98,7 +99,7 @@ T.ComboBox {
 		rotation: root.down ? 180 : 0
 		iconData: Media.Icons.light.keyboardArrowDown
 		size: UI.Size.pixel22
-		color: root.enabled ? UI.Theme.action.active : UI.Theme.action.disabled
+		color: root.enabled ? UI.Theme.action.active.toString() : UI.Theme.action.disabled.toString()
 
 		Behavior on rotation { NumberAnimation { duration: 200; easing.type: Easing.InOutQuad } }
 	}
@@ -107,7 +108,7 @@ T.ComboBox {
 		required property int index
 		required property var model
 
-		implicitHeight: UI.Size.pixel46
+		implicitHeight: root.delegateHeight
 		horizontalPadding: UI.Size.pixel12
 		width: ListView.view.width
 		useIcons: false
@@ -143,7 +144,7 @@ T.ComboBox {
 		contentItem: ListView {
 			id: _listView
 
-			implicitHeight: count > root.delegateCount ? root.delegateCount * root.delegate.height : contentHeight
+			implicitHeight: count > root.delegateCount ? root.delegateCount * root.delegateHeight : count * root.delegateHeight
 
 			model: root.delegateModel
 

--- a/Controls/Sidebar/CompactSidebar.qml
+++ b/Controls/Sidebar/CompactSidebar.qml
@@ -67,6 +67,7 @@ Item {
                 icon.iconData: _delegate.data.icon
                 category: _delegate.data.category
                 model: _delegate.data.model ?? []
+                hidden: _delegate.data.hidden
 
                 onClicked: typeof _delegate.data.onClicked === "function" ? _delegate.data.onClicked() : () => {}
 

--- a/Controls/Sidebar/ExtendedSidebar.qml
+++ b/Controls/Sidebar/ExtendedSidebar.qml
@@ -130,6 +130,7 @@ Item {
                 category: _delegate.data.category
                 model: _delegate.data.model ?? []
                 chip: _delegate.data.chip
+                hidden: _delegate.data.hidden
 
                 onClicked: typeof _delegate.data.onClicked === "function" ? _delegate.data.onClicked() : () => {}
             }

--- a/Controls/Sidebar/MobileSidebar.qml
+++ b/Controls/Sidebar/MobileSidebar.qml
@@ -39,7 +39,7 @@ Item {
 
             property SidebarItem data: root.model[index]
 
-            width: UI.Size.pixel36 * 2
+            width: _delegate.data.hidden ? 0 : UI.Size.pixel36 * 2
             height: barList.height
 
             sidebarData: root.sidebarData

--- a/Controls/Sidebar/MobileSidebar.qml
+++ b/Controls/Sidebar/MobileSidebar.qml
@@ -47,6 +47,7 @@ Item {
             icon.iconData: _delegate.data.icon
             category: _delegate.data.category
             model: _delegate.data.model ?? []
+            hidden: _delegate.data.hidden
 
             contextMenu {
                 x: 0

--- a/Controls/Sidebar/SidebarCompactItem.qml
+++ b/Controls/Sidebar/SidebarCompactItem.qml
@@ -24,6 +24,7 @@ Controls.Checkable {
     property alias contextMenu: _contextMenu
 
     property bool isOpen: false
+    property bool hidden: false
 
     function selectItem(subindex) : void {
         if (ListView.view) {
@@ -35,7 +36,8 @@ Controls.Checkable {
     }
 
     implicitWidth: ListView.view ? ListView.view.width : 0
-    implicitHeight: 54 * UI.Size.scale
+    implicitHeight: _root.hidden ? 0 : 54 * UI.Size.scale
+    clip: true
 
     checked: _root.sidebarData.currentIndex === index
     customCheckImplementation: true

--- a/Controls/Sidebar/SidebarExtendedItem.qml
+++ b/Controls/Sidebar/SidebarExtendedItem.qml
@@ -26,6 +26,7 @@ Item {
     property bool isOpen: false
 
     property real openingSpeed: 150
+    property bool hidden: false
 
     function selectItem(subindex) : void {
 		if (ListView.view) {
@@ -43,8 +44,9 @@ Item {
 
     signal clicked
 
-    height: _listView.height + _listView.anchors.topMargin + _mainItem.height
+    height: _root.hidden ? 0 : (_listView.height + _listView.anchors.topMargin + _mainItem.height)
     width: ListView.view ? ListView.view.width : 0
+    clip: true
 
     states: [
         State{

--- a/Controls/Sidebar/SidebarItem.qml
+++ b/Controls/Sidebar/SidebarItem.qml
@@ -19,5 +19,5 @@ Item {
 
     property var onClicked
 
-
+    property bool hidden: false
 }


### PR DESCRIPTION
## Combobox height fix 
  
- The original code used `root.delegate.height` in the conditional, but delegate height wasn't guaranteed to be available during height calculations, leading to popup collapse. The new approach uses a reliable property-based calculation that works consistently regardless of delegate instantiation state.

## Add `hidden` property to SidebarItem for proper dynamic visibility control

### Problem
Using Qt's `visible` property on Sidebar delegates  was not effective on binding updates for dynamic show/hide.

### Solution
Added `hidden` property following;
- Users set `hidden: true/false` 
- Delegates use `height: hidden ? 0 : normalHeight` (no gaps, proper binding)
- Works across all sidebar layouts.

### Usage
```qml
Sidebar.SidebarItem {
    text: "Admin Panel"
    hidden: userRole !== "admin"
}